### PR TITLE
Fix migration file

### DIFF
--- a/db/migrate/20190518085730_add_address_to_users.rb
+++ b/db/migrate/20190518085730_add_address_to_users.rb
@@ -1,5 +1,0 @@
-class AddAddressToUsers < ActiveRecord::Migration[5.2]
-  def change
-    add_column :users, :address, :string
-  end
-end


### PR DESCRIPTION
削除　db/migrate/20190518085730_add_address_to_users.rb
20190515081126_devise_create_users.rb
アドレスcloumを追加しているため