### PR TITLE
receiptの作成

### DIFF
--- a/app/controllers/admins/cds_controller.rb
+++ b/app/controllers/admins/cds_controller.rb
@@ -39,7 +39,8 @@ class Admins::CdsController < Admins::AdminsController
 	private
 		def cd_params
 			params.require(:cd).permit(:artist_id, :label_id, :genre_id, :release,
-			 :price, :stock, :single_album_name, :cd_image, songs_attributes: [:disc_num, :song_title])
+			 :price, :stock, :single_album_name, :cd_image)
+			 # , songs_attributes: [:disc_num, :song_title])
 		end
 
 end

--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -3,16 +3,32 @@ class ReceiptsController < ApplicationController
 def new
   @receipt = Receipt.new
   @othersaddress = Othersaddress.all
+  # @receipt.purchases.build
 end
 
 def create
-   receipt = Receipt.new(receipt_params)
-   receipt.save
+   @receipt = Receipt.new(receipt_params)
+   @receipt.save
+    logger.debug @receipt.errors.to_yaml
+   redirect_to thanks_path
 end
 
   private
   def receipt_params
-  params.require(:receipt).permit(:shipping_familyname, :shipping_firstname, :shipping_kana_familyname, :shipping_kana_firstname, :shipping_postal, :shipping_address, :shipping_telephone_number)
+  params.require(:receipt).permit(
+        :shipping_familyname,
+        :shipping_firstname,
+        :shipping_kana_familyname,
+        :shipping_kana_firstname,
+        :shipping_postal,
+        :shipping_address,
+        :shipping_telephone_number,
+        :user_id,
+        :payment,
+        :status,
+        :postage,
+        addresses_attributes: [:id, :cd_id, :purchase_price]
+        )
   end
 
 end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,6 +1,8 @@
 class Receipt < ApplicationRecord
   has_many :purchases
+  # accepts_nested_attributes_for :purchases
   belongs_to :user
+  
   enum payment: { 銀行振込:1, クレジットカード:2, 代金引換:3 }
   enum status: { 未発送: 1, 発送済: 2 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,6 @@
       <div class="menu" id="open-navbar1">
         <ul class="list">
           <li><a href="#">Home</a></li>
-          
           <li><a href="http://dev.gilan-co.com/">About us</a></li>
           <li><%= link_to  do %>
             <span>マイページ</span>

--- a/app/views/receipts/new.html.erb
+++ b/app/views/receipts/new.html.erb
@@ -1,36 +1,120 @@
 <div class="container">
+  <h1>注文内容の確認・変更</h1>
+  <div class="row">
+    <div class="col-sm-6">
 
-<h1>注文内容の確認・変更</h1>
+      <%= form_for(@receipt) do |f| %>
+      <h4>配送先住所</h4>
+      <div class="card my-2">
+        <div class="card-body">
+          <h5 class="card-title">注文者の住所に送る</h5>
+              <div class="row">
+                <div class="col-sm-6 mb-1">
+                  <%= f.label :shipping_kana_familyname, "カナ(姓)" %>
+                  <%= f.text_field :shipping_kana_familyname ,value: current_user.kana_familyname,
+                   readonly: true, class: "form-control" %>
+                </div>
+                <div class="col-sm-6 mb-1">
+                  <%= f.label :shipping_kana_firstname, "カナ(名)" %>
+                  <%= f.text_field :shipping_kana_firstname ,value: current_user.kana_firstname, readonly: true, class: "form-control" %>
+                </div>
+                <div class="col-sm-6 mb-1">
+                  <%= f.label :shipping_familyname, "姓" %>
+                  <%= f.text_field :shipping_familyname ,value: current_user.familyname, readonly: true, class: "form-control" %>
+                </div>
+                <div class="col-sm-6 mb-1">
+                  <%= f.label :shipping_firstname, "名" %>
+                  <%= f.text_field :shipping_firstname ,value: current_user.firstname, readonly: true, class: "form-control" %>
+                </div>
+                <div class="col-sm-12 mb-1">
+                  <%= f.label :shipping_telephone_number, "TEL" %>
+                  <%= f.text_field :shipping_telephone_number, value: current_user.telephone_number,
+                   readonly: true, class: "form-control" %>
+                </div>
+                <div class="col-sm-3 mb-1">
+                  <%= f.label :shipping_postal, "郵便番号" %>
+                  <%= f.text_field :shipping_postal, value: current_user.postal_code, readonly: true, class: "form-control" %>
+                </div>
+                <div class="col-sm-12 mb-1">
+                  <%= f.label :shipping_address, "住所" %>
+                  <%= f.text_field :shipping_address, value: current_user.address, readonly: true, class: "form-control" %>
+                </div>
+                  <%= f.hidden_field :user_id, value:current_user.id %>
+              </div>
 
-<h4>配送先住所</h4>
-
-<%= form_for(@receipt) do |f| %>
-
-<%= f.collection_select :user_id, User.all, :id, :address %>
-
-<ul>
-   <%= link_to "お届け先の追加", new_othersaddress_path, class: "btn btn-primary" %>
-</ul>
-<p>支払方法</p>
-
-<label>
-  <%= f.radio_button :payment, "1" %>銀行振込</label>
-<label>
-  <%= f.radio_button :payment, "2" %>クレジットカード</label>
-<label>
-  <%= f.radio_button :payment, "3" %>代金引換え</label>
+        </div>
+      </div>
 
 
-<p>配送方法: まとめて配送する</p>
+      <div class="card my-2">
+      <div class="card-body">
+        <h5 class="card-title">
+          <label>別の住所に送る<span class="text-right"><%= link_to "お届け先の追加", new_othersaddress_path, class: "btn btn-primary" %></span></label>
+        </h5>
+        <p><%= current_user.kana_familyname %> <%= current_user.kana_firstname %></p>
+        <p><%= current_user.familyname %> <%= current_user.firstname %></p>
+        <p>〒151-0001</p>
+        <p>東京都渋谷区神南1-11-1</p>
+      </div>
+    </div>
 
-<%= f.submit "購入する" %>
+    </div>
+    <div class="col-sm-6">
+        <p>支払方法</p>
+        <table class="table table-bordered">
+          <tr>
+            <th class="table-active">支払い方法</th>
+            <td>
+              <label><%= f.radio_button :payment, :銀行振込, checked: "checked" %>  銀行振込</label>
+              <label><%= f.radio_button :payment, :クレジットカード %>  クレジットカード</label>
+              <label><%= f.radio_button :payment, :代金引換 %>  代金引換</label>
 
-<% end %>
-#住所選択をさせる
-<% @othersaddress.each do |address| %>
+            </td>
+          </tr>
+          <tr>
+            <th class="table-active">配送方法</th>
+            <td>まとめて配送</td>
+            <%= f.hidden_field :status, { value: :未発送 } %>
+          </tr>
+          <tr>
+          </tr>
+          <tr>
+            <th class="table-active">商品の小計</th>
+            <td>¥5,000</td>
+          </tr>
+          <tr>
+            <th class="table-active">配送料・手数料</th>
+            <td>¥500</td>
+            <%= f.hidden_field :postage, { value: 500 } %>
+          </tr>
+          <tr>
+            <th class="table-active">注文合計</th>
+            <td>¥5,500</td>
+          </tr>
+        </table>
+        <!-- 未完成　メソッドとして成立してない気がする
+          each文で全てのpurchaseにreceipt_idを付与したい。。
+              <% current_user.carts.each do |purchase| %>
+                <%= f.fields_for :purchase, purchase do |p| %>
+                  <%= p.hidden_field :cd_id, { value: purchase.cd.id } %>
+                  <%= p.hidden_field :purchase_price, { value: 500 } %>
+                <% end %>
+              <% end %>
+            -->
+        
 
-<%= address.address %>
-<% end %>
+        <div class="text-center">
+          <%= f.submit "注文を確定する", class: "btn btn-outline-primary btn-lg" %>
+    <% end %>
+    </div>
+
+
+  </div>
+<!--
+  <% @othersaddress.each do |address| %>
+
+  <%= address.address %>
+    <% end %>-->
 
 
 </div>


### PR DESCRIPTION
URL => receipt/new

<<実施項目>>
・レイアウト変更
・現住所での登録

<<課題>>
（１）登録ボタンを押した際に、purchaseも同時に作成したい。
コメントアウトしているものは、頑張った痕跡です。
これはまだ実装できていません。
（２）別住所での登録

24日(金)、25日(土)は結婚式参加で、神戸に帰省するので、作業できません。
ひとまず、pull requestします。現状は、ほとんど進んでいません。。

よろしくお願いいたします。