### PR TITLE
管理画面　購入履歴一覧ページ　アクセスエラー #75

### DIFF
--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,5 +1,5 @@
 class Receipt < ApplicationRecord
-  has_many :purchases, dependent: :destory
+  has_many :purchases, dependent: :destroy
   accepts_nested_attributes_for :purchases
   belongs_to :user
 

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,5 +1,5 @@
 class Receipt < ApplicationRecord
-  has_many :purchases
+  has_many :purchases, dependent: :destory
   accepts_nested_attributes_for :purchases
   belongs_to :user
 


### PR DESCRIPTION
receiptが削除されたとき、それに紐付いているpurchasesが削除されていないためエラーが起こっていました。
receiptモデルdependentオプション追加しました。