### PR TITLE
フロント　カート画面　同一商品の複数表示 #80

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -11,7 +11,6 @@
 
   #カートに商品を追加する
   def create
-    byebug
     cart = Cart.find_by(
       user_id: current_user.id,
       cd_id: cart_params[:cd_id]

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -9,17 +9,31 @@
     @total_price = 0
   end
 
- #カートに商品を追加する
+  #カートに商品を追加する
   def create
-   @cart = Cart.new(cart_params)
-   if  @cart.cd.stock.to_i > 0
-      @cart.save
+    cart = Cart.find_by(
+      user_id: current_user.id,
+      cd_id: cart_params[:cd_id]
+    )
+
+    if cart.present?
+      # update
+      # 既存のカートレコードに数量を追加
+      cart.amount += cart_params[:amount].to_i
+    else
+      # create
+      # 新規でレコードを作成
+      cart = Cart.new(cart_params)
+    end
+
+    if cart.cd.stock.to_i > 0
+      cart.save
       flash[:notice] = "カートに商品が追加されました"
       redirect_to carts_path
-   else
-    flash[:notice] = "品切れのため商品を追加できません。"
-    render "cds/show"
-   end
+    else
+      flash[:notice] = "品切れのため商品を追加できません。"
+      render "cds/show"
+    end
   end
 
 #カート商品の数量変更


### PR DESCRIPTION
同一商品がカートにある場合に関して

商品をカート追加した際のロジックを変更しました。

変更前
別レコードとして商品をカートに追加しView画面で同一商品が２つ表示される

変更後
既に同一商品がある場合は、新たに追加した個数を上乗せしてアップデート

確認よろしくお願いします。

