### PR TITLE
fix othersaddress

### DIFF
--- a/app/models/othersaddress.rb
+++ b/app/models/othersaddress.rb
@@ -33,7 +33,7 @@ class Othersaddress < ApplicationRecord
   # 住所の仮想カラム
   attr_accessor :statu_address, :city_address, :street_address
 
-  validates :statu_address, :city_address, :street_address, presence: true
+  validates :statu_address, :city_address, presence: true
 
   #
   before_validation :set_address

--- a/app/views/othersaddresses/new.html.erb
+++ b/app/views/othersaddresses/new.html.erb
@@ -1,6 +1,15 @@
 
 <div class="container">
    <h1>新しいお届け先の追加</h1>
+   <% if @othersaddress.errors.any? %>
+   <div id="error_explanation" class="alert alert-danger">
+    <ul>
+      <% @othersaddress.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+  <% end %>
   <%= form_for (@othersaddress) do |f| %>
      <div class="field">
     <%= f.label :性 %><br />
@@ -27,7 +36,7 @@
     <%= f.text_field :first_postal_code, :size=>"5" %>
     <span>−</span>
     <%= f.text_field :last_postal_code, :size=>"5" %> ※半角数字でお願いいたします
-  </span>
+  </span><br />
         <span class="field">
           <%= f.label :都道府県 %><br />
        <%= f.select :statu_address, ["北海道","青森県","岩手県","宮城県","秋田県","山形県","福島県","茨城県","栃木県","群馬県","埼玉県","千葉県","東京都","神奈川県","新潟県","富山県","石川県","福井県","山梨県","長野県","岐阜県","静岡県","愛知県","三重県","滋賀県","京都府","大阪府","兵庫県","奈良県","和歌山県","鳥取県","島根県","岡山県","広島県","山口県","徳島県","香川県","愛媛県","高知県","福岡県","佐賀県","長崎県","熊本県","大分県","宮崎県","鹿児島県","沖縄県"], :prompt => "選択してください", :size => "15" %><br />


### PR DESCRIPTION
マンション名が登録必須になっている
→バリデーション制約からマンション名を削除し、空白でも登録出来るようにしました。

エラーメッセージが表示されない
→エラーメッセージが表示されるようにしました。

他
・レイアウト一部修正